### PR TITLE
Update compile-project

### DIFF
--- a/compile-project
+++ b/compile-project
@@ -77,6 +77,7 @@ if [ "$result" != 222 ] ; then
   # A buildfile was found, exit with the exit code of the compilation step.
   exit $result
 else
+  # Call compile_in_directory in subdirectories.
   buildfile_found=0
   for subdir in "$toplevel"/*/ ; do
     compile_in_directory "$subdir"

--- a/compile-project
+++ b/compile-project
@@ -89,4 +89,7 @@ if [ "$result" = 222 ] ; then
   if [ "$buildfile_found" = 0 ] && [ -n "$ERR_IF_NO_BUILDFILE" ]; then
     exit 1
   fi
+else
+  # A buildfile was found, exit with the exit code of the compilation step.
+  exit $result
 fi

--- a/compile-project
+++ b/compile-project
@@ -73,7 +73,10 @@ compile_in_directory() {
 compile_in_directory "$toplevel"
 result=$?
 
-if [ "$result" = 222 ] ; then
+if [ "$result" != 222 ] ; then
+  # A buildfile was found, exit with the exit code of the compilation step.
+  exit $result
+else
   buildfile_found=0
   for subdir in "$toplevel"/*/ ; do
     compile_in_directory "$subdir"
@@ -89,7 +92,4 @@ if [ "$result" = 222 ] ; then
   if [ "$buildfile_found" = 0 ] && [ -n "$ERR_IF_NO_BUILDFILE" ]; then
     exit 1
   fi
-else
-  # A buildfile was found, exit with the exit code of the compilation step.
-  exit $result
 fi


### PR DESCRIPTION
When a buildfile is found (i.e., the exit code of the compilation step is NOT `222`), the script should exit with the code from running one of Maven, Gradle, or Make.

Carrying over from our conversation [here](https://github.com/jyoo980/compile-list-of-projects/issues/1#issuecomment-1728522521).
